### PR TITLE
Fix app-initializer-initialize-arguments for Ember 2.1

### DIFF
--- a/app/initializers/ember-cli-dates.js
+++ b/app/initializers/ember-cli-dates.js
@@ -8,7 +8,8 @@ import { monthAndYear } from 'ember-cli-dates/helpers/month-and-year';
 import { monthAndDay } from 'ember-cli-dates/helpers/month-and-day';
 import { dateAndTime } from 'ember-cli-dates/helpers/date-and-time';
 
-export var initialize = function(container, app) {
+export var initialize = function() {
+  let app = arguments[1] || arguments[0];
   app.TimeFormatHelper = Ember.Helper.helper(timeFormat);
   app.TimeAgoInWordsHelper = Ember.Helper.helper(timeAgoInWords);
   app.DayOfTheWeekHelper = Ember.Helper.helper(dayOfTheWeek);


### PR DESCRIPTION
Taken from http://emberjs.com/deprecations/v2.x/#toc_initializer-arity

This supports the new and the old way.